### PR TITLE
ramips: add support for JCG Y2

### DIFF
--- a/target/linux/ramips/dts/mt7621_jcg_y2.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_y2.dts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "jcg,y2", "mediatek,mt7621-soc";
+	model = "JCG Y2";
+
+	aliases {
+		led-boot = &led_internet;
+		led-failsafe = &led_internet;
+		led-upgrade = &led_internet;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_internet: internet {
+			label = "blue:internet";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+		mtd-mac-address = <&factory 0x4>;
+	};
+};
+
+&ethernet {
+	compatible = "mediatek,ralink-mt7621-eth";
+	mediatek,switch = <&gsw>;
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&switch0 {
+	/* must delete compatible property */
+	/delete-property/ compatible;
+	phy-mode = "rgmii";
+};
+
+&gsw {
+	compatible = "mediatek,ralink-mt7621-gsw";
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -651,6 +651,18 @@ define Device/jcg_jhr-ac876m
 endef
 TARGET_DEVICES += jcg_jhr-ac876m
 
+define Device/jcg_y2
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 16064k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | jcg-header 95.1
+  JCG_MAXSIZE := 16064k
+  DEVICE_VENDOR := JCG
+  DEVICE_MODEL := Y2
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7615-firmware kmod-usb3
+endef
+TARGET_DEVICES += jcg_y2
+
 define Device/lenovo_newifi-d1
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -27,7 +27,8 @@ dlink,dir-878-a1|\
 dlink,dir-882-a1)
 	ucidef_set_led_netdev "wan" "wan" "green:net" "wan"
 	;;
-gehua,ghl-r-001)
+gehua,ghl-r-001|\
+jcg,y2)
 	ucidef_set_led_switch "internet" "internet" "blue:internet" "switch0" "0x10"
 	;;
 gnubee,gb-pc1|\

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -48,6 +48,10 @@ ramips_setup_interfaces()
 	xiaomi,mir3p)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;
+	jcg,y2)
+		ucidef_add_switch "switch0" \
+			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "6@eth0"
+		;;
 	linksys,re6500|\
 	netgear,wac104)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
@@ -161,6 +165,11 @@ ramips_setup_macs()
 	iodata,wnpr2600g)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		label_mac=$wan_mac
+		;;
+	jcg,y2)
+		lan_mac=$(cat /sys/class/net/eth0/address)
+		wan_mac=$(mtd_get_mac_binary factory 0xe006)
+		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
 	linksys,ea7300-v1|\
 	linksys,ea7300-v2|\

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/05_compat-version
@@ -11,6 +11,7 @@ board_config_update
 case "$(board_name)" in
 	d-team,newifi-d2|\
 	gehua,ghl-r-001|\
+	jcg,y2|\
 	netgear,r6220|\
 	netgear,wndr3700-v5|\
 	phicomm,k2p|\


### PR DESCRIPTION
JCG Y2 is an AC1300M router

Hardware specs:
  SoC: MediaTek MT7621AT
  Flash: Winbond W25Q128JVSQ 16MiB
  RAM: Nanya NT5CB128M16 256MiB
  2.4GHz: MT7615D 2x2
  5GHz: MT7615D 2x2
  Ethernet: 1 x WAN and 4 x LAN
  LED: 2.4G, 5G, INTERNET, POWER
  USB: 1 x 3.0
  Button: Reset

Flash instructions:
  Upload factory.bin in stock firmware's upgrade page.