### PR TITLE
qualcommax: switch to cortex-a73 and optimizations

### DIFF
--- a/target/linux/qualcommax/Makefile
+++ b/target/linux/qualcommax/Makefile
@@ -5,7 +5,7 @@ BOARD:=qualcommax
 BOARDNAME:=Qualcomm Atheros 802.11ax WiSoC-s
 FEATURES:=squashfs ramdisk fpu nand rtc emmc
 KERNELNAME:=Image dtbs
-CPU_TYPE:=cortex-a53
+CPU_TYPE:=cortex-a73
 SUBTARGETS:=ipq807x ipq60xx
 
 KERNEL_PATCHVER:=6.1

--- a/target/linux/qualcommax/patches-6.1/9999-qualcommax-a73-optimizations.patch
+++ b/target/linux/qualcommax/patches-6.1/9999-qualcommax-a73-optimizations.patch
@@ -1,0 +1,13 @@
+--- a/Makefile	2024-03-25 19:34:08.989713592 +0800
++++ b/Makefile	2024-03-25 19:33:52.584640195 +0800
+@@ -834,6 +834,9 @@
+ KBUILD_RUSTFLAGS += -Copt-level=s
+ endif
+ 
++KBUILD_CFLAGS += -mcpu=cortex-a73+crypto+aes+sha2 -mtune=cortex-a73 
++KBUILD_AFLAGS += -mcpu=cortex-a73+crypto+aes+sha2 -mtune=cortex-a73 
++
+ # Always set `debug-assertions` and `overflow-checks` because their default
+ # depends on `opt-level` and `debug-assertions`, respectively.
+ KBUILD_RUSTFLAGS += -Cdebug-assertions=$(if $(CONFIG_RUST_DEBUG_ASSERTIONS),y,n)
+


### PR DESCRIPTION
$ cat /proc/cpuinfo
processor : 0
BogoMIPS : 48.00
Features : fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid CPU implementer : 0x51
CPU architecture: 8
CPU variant : 0xa
CPU part : 0x801
CPU revision : 4

CPU is actually Kryo 2xx Silver (265? 280?)

Implementer 0x51, Part 0x801
https://github.com/llvm/llvm-project/blob/main/llvm/lib/TargetParser/Host.cpp#L294 
LLVM tells me that this is actually closer to a cortex a73 chip.

another thing, at dmesg Linux detects Spectre-BHB
[    0.000000] CPU features: detected: Spectre-v4
which is not a vulnerability of Cortex-A53
https://developer.arm.com/Arm%20Security%20Center/Spectre-BHB

https://github.com/gcc-mirror/gcc/blob/releases/gcc-13.2.0/libgo/go/golang.org/x/sys/cpu/cpu_arm64.go#L11 https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html

whats missing is aes and sha2, added them to kernel optimizations
(pmull is already covered by aes)
