### PR TITLE
ramips: add support for Mercusys AC12G v1 (with 8MB flash memory)

### DIFF
--- a/target/linux/ramips/dts/mt7620a_mercusys_ac12g-v1-8m.dts
+++ b/target/linux/ramips/dts/mt7620a_mercusys_ac12g-v1-8m.dts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/leds/common.h>
+
+#include "mt7620a_tplink_8m.dtsi"
+
+/ {
+	compatible = "mercusys,ac12g-v1-8m", "ralink,mt7620a-soc";
+	model = "Mercusys AC12G v1 (8M)";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: led-0 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led-2 {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	/delete-node/ keys;
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	rtl8367s {
+		compatible = "realtek,rtl8367b";
+		realtek,extif = <7 1 0 1 1 1 1 1 1 2>;
+		mii-bus = <&mdio0>;
+		phy-id = <29>;
+	};
+};
+
+&spi0 {
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uartf", "ephy", "rgmii2";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &mdio_pins>;
+
+	port@5 {
+		status = "okay";
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-mode = "rgmii";
+	};
+
+	mdio0: mdio-bus {
+		status = "okay";
+		reset-gpios = <&gpio2 20 GPIO_ACTIVE_LOW>;
+		reset-delay-us = <10000>;
+	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&wmac {
+	pinctrl-names = "default", "pa_gpio";
+	pinctrl-0 = <&pa_pins>;
+	pinctrl-1 = <&pa_gpio_pins>;
+
+	nvmem-cells = <&eeprom_radio_0>, <&macaddr_rom_f100 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&wifi {
+	nvmem-cells = <&eeprom_radio_8000>, <&macaddr_rom_f100 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -802,6 +802,8 @@ define Device/mercusys_ac12g-v1-8m
   TPLINK_HWID := 0x04da857c
   TPLINK_HWREV := 0x0c000600
   TPLINK_HWREVADD := 0x04000000
+  KERNEL := kernel-bin | append-dtb | lzma -d22
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma -d22 | tplink-v2-header -e
   IMAGES += tftp-recovery.bin
   IMAGE/tftp-recovery.bin := pad-extra 128k | $$(IMAGE/factory.bin)
   DEVICE_VENDOR := Mercusys

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -794,6 +794,23 @@ define Device/linksys_e1700
 endef
 TARGET_DEVICES += linksys_e1700
 
+define Device/mercusys_ac12g-v1-8m
+  $(Device/tplink-v2)
+  SOC := mt7620a
+  IMAGE_SIZE := 7808k
+  TPLINK_FLASHLAYOUT := 8Mmtk
+  TPLINK_HWID := 0x04da857c
+  TPLINK_HWREV := 0x0c000600
+  TPLINK_HWREVADD := 0x04000000
+  IMAGES += tftp-recovery.bin
+  IMAGE/tftp-recovery.bin := pad-extra 128k | $$(IMAGE/factory.bin)
+  DEVICE_VENDOR := Mercusys
+  DEVICE_MODEL := AC12G
+  DEVICE_VARIANT := v1 (8M)
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-switch-rtl8367b
+endef
+TARGET_DEVICES += mercusys_ac12g-v1-8m
+
 define Device/microduino_microwrt
   SOC := mt7620a
   IMAGE_SIZE := 16128k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -234,6 +234,7 @@ tplink,archer-c20i)
 	ucidef_set_led_switch "lan" "lan" "blue:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "blue:wan" "switch0" "0x01"
 	;;
+mercusys,ac12g-v1-8m|\
 tplink,archer-c5-v4)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch1" "0x0f"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch1" "0x10"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -237,6 +237,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan:3" "2:lan:4" "3:lan:1" "4:lan:2" "0:wan" "6@eth0"
 		;;
+	mercusys,ac12g-v1-8m|\
 	tplink,archer-c5-v4)
 		ucidef_add_switch "switch0"
 		ucidef_add_switch_attr "switch0" "enable" "0"


### PR DESCRIPTION
Since OpenWRT does not support modded devices, I suggest adding Mercusys AC12G v1 to this repository.

Mercusys AC12G v1 can be supported by OpenWRT if we replace the flash memory installed in it from 2MB to 8MB (e.g. Winbond W25Q64FVSIG) to which we upload the original image from the TP-Link Archer C5 v4 router but with a few corrections. For this you will need a memory programmer, a soldering iron and a TP-Link Archer C5 v4 memory dump.

You should carefully desolder the memory and then read it with a programmer. The read dump should be copied to the Archer C5 v4 dump in the following areas:
from addresses 1FE000-1FE005 to 7DF100-7DF105
from addresses 1FF000-1FF7FF to 7F0000-7F07FF
from addresses 1FF800-1FFFFF to 7F8000-7F87FF
The corrected image should be programmed into 8MB flash memory and soldered.

Once your router is up and running, update it to the latest version from the TP-Link website.

The latest version has a TFTP recovery function, so you can easily change the firmware to OpenWRT:
-rename openwrt-ramips-mt7620-mercusys_ac12g-v1-8m-squashfs-tftp-recovery.bin to tp_recovery.bin
-change the IP address of the computer to 192.168.0.66, connect to the LAN port of the router.
-start the TFTP server
-restart the router with the reset button pressed, the file will be automatically downloaded and after a while the router will restart. After updating, set your computer's IP address to DHCP.

A little note 1: Since there are problems with the performance of 2.4GHz WiFi for Mediatek MT7620 with enabled 802.11w Management Frame Protection, use WPA2-PSK security. For 5GHz this problem does not occur, so you can enable WPA3-SAE or WPA2-PSK/WPA3-SAE security mode.

A little note 2: Limit the WiFi power to that allowed in your country because OpenWrt does not take into account the antenna gain for this router (5dBi).


Additionally, reduce the size of the LZMA dictionary (from 8 MB to 4 MB) to reduce the amount of memory needed for unpacking and prevent LZMA ERROR 1 (if we compile with additional modules that increase the image size).
The image is a bit larger, but the 4 MB saved makes it unpack correctly


